### PR TITLE
add light colors, use 38;5;N instead of 3N, styled and colored buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,24 +37,40 @@
                 <p>Foreground Color:</p>
                 <button class="fgcolor-btn">Default</button>
                 <button class="fgcolor-btn">Black</button>
-                <button class="fgcolor-btn">Red</button>
-                <button class="fgcolor-btn">Green</button>
-                <button class="fgcolor-btn">Yellow</button>
-                <button class="fgcolor-btn">Blue</button>
-                <button class="fgcolor-btn">Magenta</button>
-                <button class="fgcolor-btn">Cyan</button>
+                <button class="fgcolor-btn">Dark Red</button>
+                <button class="fgcolor-btn">Dark Green</button>
+                <button class="fgcolor-btn">Dark Yellow</button>
+                <button class="fgcolor-btn">Dark Blue</button>
+                <button class="fgcolor-btn">Dark Magenta</button>
+                <button class="fgcolor-btn">Dark Cyan</button>
+                <button class="fgcolor-btn">Light Gray</button>
+                <button class="fgcolor-btn">Dark Gray</button>
+                <button class="fgcolor-btn">Light Red</button>
+                <button class="fgcolor-btn">Light Green</button>
+                <button class="fgcolor-btn">Light Yellow</button>
+                <button class="fgcolor-btn">Light Blue</button>
+                <button class="fgcolor-btn">Light Magenta</button>
+                <button class="fgcolor-btn">Light Cyan</button>
                 <button class="fgcolor-btn">White</button>
             </div>
             <div class="submenu">
                 <p>Background Color:</p>
                 <button class="bgcolor-btn">Default</button>
                 <button class="bgcolor-btn">Black</button>
-                <button class="bgcolor-btn">Red</button>
-                <button class="bgcolor-btn">Green</button>
-                <button class="bgcolor-btn">Yellow</button>
-                <button class="bgcolor-btn">Blue</button>
-                <button class="bgcolor-btn">Magenta</button>
-                <button class="bgcolor-btn">Cyan</button>
+                <button class="bgcolor-btn">Dark Red</button>
+                <button class="bgcolor-btn">Dark Green</button>
+                <button class="bgcolor-btn">Dark Yellow</button>
+                <button class="bgcolor-btn">Dark Blue</button>
+                <button class="bgcolor-btn">Dark Magenta</button>
+                <button class="bgcolor-btn">Dark Cyan</button>
+                <button class="bgcolor-btn">Light Gray</button>
+                <button class="bgcolor-btn">Dark Gray</button>
+                <button class="bgcolor-btn">Light Red</button>
+                <button class="bgcolor-btn">Light Green</button>
+                <button class="bgcolor-btn">Light Yellow</button>
+                <button class="bgcolor-btn">Light Blue</button>
+                <button class="bgcolor-btn">Light Magenta</button>
+                <button class="bgcolor-btn">Light Cyan</button>
                 <button class="bgcolor-btn">White</button>
             </div>
             <div class="submenu">

--- a/index.html
+++ b/index.html
@@ -36,49 +36,49 @@
             <div class="submenu">
                 <p>Foreground Color:</p>
                 <button class="fgcolor-btn">Default</button>
-                <button class="fgcolor-btn">Black</button>
-                <button class="fgcolor-btn">Dark Red</button>
-                <button class="fgcolor-btn">Dark Green</button>
-                <button class="fgcolor-btn">Dark Yellow</button>
-                <button class="fgcolor-btn">Dark Blue</button>
-                <button class="fgcolor-btn">Dark Magenta</button>
-                <button class="fgcolor-btn">Dark Cyan</button>
-                <button class="fgcolor-btn">Light Gray</button>
-                <button class="fgcolor-btn">Dark Gray</button>
-                <button class="fgcolor-btn">Light Red</button>
-                <button class="fgcolor-btn">Light Green</button>
-                <button class="fgcolor-btn">Light Yellow</button>
-                <button class="fgcolor-btn">Light Blue</button>
-                <button class="fgcolor-btn">Light Magenta</button>
-                <button class="fgcolor-btn">Light Cyan</button>
-                <button class="fgcolor-btn">White</button>
+                <button class="fgcolor-btn btn-black"        >Black</button>
+                <button class="fgcolor-btn btn-dark-red"     >Dark Red</button>
+                <button class="fgcolor-btn btn-dark-green"   >Dark Green</button>
+                <button class="fgcolor-btn btn-dark-yellow"  >Dark Yellow</button>
+                <button class="fgcolor-btn btn-dark-blue"    >Dark Blue</button>
+                <button class="fgcolor-btn btn-dark-magenta" >Dark Magenta</button>
+                <button class="fgcolor-btn btn-dark-cyan"    >Dark Cyan</button>
+                <button class="fgcolor-btn btn-light-gray"   >Light Gray</button>
+                <button class="fgcolor-btn btn-dark-gray"    >Dark Gray</button>
+                <button class="fgcolor-btn btn-light-red"    >Light Red</button>
+                <button class="fgcolor-btn btn-light-green"  >Light Green</button>
+                <button class="fgcolor-btn btn-light-yellow" >Light Yellow</button>
+                <button class="fgcolor-btn btn-light-blue"   >Light Blue</button>
+                <button class="fgcolor-btn btn-light-magenta">Light Magenta</button>
+                <button class="fgcolor-btn btn-light-cyan"   >Light Cyan</button>
+                <button class="fgcolor-btn btn-white"        >White</button>
             </div>
             <div class="submenu">
                 <p>Background Color:</p>
                 <button class="bgcolor-btn">Default</button>
-                <button class="bgcolor-btn">Black</button>
-                <button class="bgcolor-btn">Dark Red</button>
-                <button class="bgcolor-btn">Dark Green</button>
-                <button class="bgcolor-btn">Dark Yellow</button>
-                <button class="bgcolor-btn">Dark Blue</button>
-                <button class="bgcolor-btn">Dark Magenta</button>
-                <button class="bgcolor-btn">Dark Cyan</button>
-                <button class="bgcolor-btn">Light Gray</button>
-                <button class="bgcolor-btn">Dark Gray</button>
-                <button class="bgcolor-btn">Light Red</button>
-                <button class="bgcolor-btn">Light Green</button>
-                <button class="bgcolor-btn">Light Yellow</button>
-                <button class="bgcolor-btn">Light Blue</button>
-                <button class="bgcolor-btn">Light Magenta</button>
-                <button class="bgcolor-btn">Light Cyan</button>
-                <button class="bgcolor-btn">White</button>
+                <button class="bgcolor-btn btn-black"        >Black</button>
+                <button class="bgcolor-btn btn-dark-red"     >Dark Red</button>
+                <button class="bgcolor-btn btn-dark-green"   >Dark Green</button>
+                <button class="bgcolor-btn btn-dark-yellow"  >Dark Yellow</button>
+                <button class="bgcolor-btn btn-dark-blue"    >Dark Blue</button>
+                <button class="bgcolor-btn btn-dark-magenta" >Dark Magenta</button>
+                <button class="bgcolor-btn btn-dark-cyan"    >Dark Cyan</button>
+                <button class="bgcolor-btn btn-light-gray"   >Light Gray</button>
+                <button class="bgcolor-btn btn-dark-gray"    >Dark Gray</button>
+                <button class="bgcolor-btn btn-light-red"    >Light Red</button>
+                <button class="bgcolor-btn btn-light-green"  >Light Green</button>
+                <button class="bgcolor-btn btn-light-yellow" >Light Yellow</button>
+                <button class="bgcolor-btn btn-light-blue"   >Light Blue</button>
+                <button class="bgcolor-btn btn-light-magenta">Light Magenta</button>
+                <button class="bgcolor-btn btn-light-cyan"   >Light Cyan</button>
+                <button class="bgcolor-btn btn-white"        >White</button>
             </div>
             <div class="submenu">
                 <p>Style:</p>
-                <button class="style-btn">Bold</button>
-                <button class="style-btn">Italic</button>
-                <button class="style-btn">Underline</button>
-                <button class="style-btn">Strikethrough</button>
+                <button class="style-btn btn-bold">Bold</button>
+                <button class="style-btn btn-italic">Italic</button>
+                <button class="style-btn btn-underline">Underline</button>
+                <button class="style-btn btn-strikethrough">Strikethrough</button>
             </div>
             <div class="submenu">
                 <p>Escape sequence:</p>

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
                 <button class="fgcolor-btn btn-dark-blue"    >Dark Blue</button>
                 <button class="fgcolor-btn btn-dark-magenta" >Dark Magenta</button>
                 <button class="fgcolor-btn btn-dark-cyan"    >Dark Cyan</button>
-                <button class="fgcolor-btn btn-light-gray"   >Light Gray</button>
+                <button class="fgcolor-btn btn-light-gray"   >Light Gray</button><br/>
                 <button class="fgcolor-btn btn-dark-gray"    >Dark Gray</button>
                 <button class="fgcolor-btn btn-light-red"    >Light Red</button>
                 <button class="fgcolor-btn btn-light-green"  >Light Green</button>
@@ -63,7 +63,7 @@
                 <button class="bgcolor-btn btn-dark-blue"    >Dark Blue</button>
                 <button class="bgcolor-btn btn-dark-magenta" >Dark Magenta</button>
                 <button class="bgcolor-btn btn-dark-cyan"    >Dark Cyan</button>
-                <button class="bgcolor-btn btn-light-gray"   >Light Gray</button>
+                <button class="bgcolor-btn btn-light-gray"   >Light Gray</button><br/>
                 <button class="bgcolor-btn btn-dark-gray"    >Dark Gray</button>
                 <button class="bgcolor-btn btn-light-red"    >Light Red</button>
                 <button class="bgcolor-btn btn-light-green"  >Light Green</button>

--- a/main.css
+++ b/main.css
@@ -77,7 +77,7 @@ button {
 }
 
 .submenu {
-    display: flex;
+    /* display: flex; */
     flex-direction: row;
     flex-wrap: wrap;
     justify-content: center;
@@ -85,7 +85,7 @@ button {
     margin: 5px 0;
 }
 .submenu > * {
-    margin: 5px 5px;
+    margin: 5px 0px;
 }
 
 .btn-bold {
@@ -99,4 +99,69 @@ button {
 }
 .btn-strikethrough {
     text-decoration: line-through;
+}
+
+.btn-black {
+    border: #000000 3px solid;
+    padding: 7px 9px;
+}
+.btn-dark-red {
+    border: #aa0000 3px solid;
+    padding: 7px 9px;
+}
+.btn-dark-green {
+    border: #00aa00 3px solid;
+    padding: 7px 9px;
+}
+.btn-dark-yellow {
+    border: #aaaa00 3px solid;
+    padding: 7px 9px;
+}
+.btn-dark-blue {
+    border: #0000aa 3px solid;
+    padding: 7px 9px;
+}
+.btn-dark-magenta {
+    border: #aa00aa 3px solid;
+    padding: 7px 9px;
+}
+.btn-dark-cyan {
+    border: #00aaaa 3px solid;
+    padding: 7px 9px;
+}
+.btn-light-gray {
+    border: #aaaaaa 3px solid;
+    padding: 7px 9px;
+}
+.btn-dark-gray {
+    border: #555555 3px solid;
+    padding: 7px 9px;
+}
+.btn-light-red {
+    border: #ff5555 3px solid;
+    padding: 7px 9px;
+}
+.btn-light-green {
+    border: #55ff55 3px solid;
+    padding: 7px 9px;
+}
+.btn-light-yellow {
+    border: #ffff55 3px solid;
+    padding: 7px 9px;
+}
+.btn-light-blue {
+    border: #5555ff 3px solid;
+    padding: 7px 9px;
+}
+.btn-light-magenta {
+    border: #ff55ff 3px solid;
+    padding: 7px 9px;
+}
+.btn-light-cyan {
+    border: #55ffff 3px solid;
+    padding: 7px 9px;
+}
+.btn-white {
+    border: #ffffff 3px solid;
+    padding: 7px 9px;
 }

--- a/main.css
+++ b/main.css
@@ -87,3 +87,16 @@ button {
 .submenu > * {
     margin: 5px 5px;
 }
+
+.btn-bold {
+    font-weight: bold;
+}
+.btn-italic {
+    font-style: italic;
+}
+.btn-underline {
+    text-decoration: underline;
+}
+.btn-strikethrough {
+    text-decoration: line-through;
+}

--- a/main.js
+++ b/main.js
@@ -8,6 +8,7 @@ window.onload = () => {
     const codes = {
         "Reset": "0",
 
+        /*
         "Black-fg":"30",
         "Dark-Red-fg":"31",
         "Dark-Green-fg":"32",
@@ -15,7 +16,15 @@ window.onload = () => {
         "Dark-Blue-fg":"34",
         "Dark-Magenta-fg":"35",
         "Dark-Cyan-fg":"36",
-        "Light-Gray-fg":"37",
+        "Light-Gray-fg":"37",*/
+        "Black-fg":"38;5;0",
+        "Dark-Red-fg":"38;5;1",
+        "Dark-Green-fg":"38;5;2",
+        "Dark-Yellow-fg":"38;5;3",
+        "Dark-Blue-fg":"38;5;4",
+        "Dark-Magenta-fg":"38;5;5",
+        "Dark-Cyan-fg":"38;5;6",
+        "Light-Gray-fg":"38;5;7",
         "Dark-Gray-fg":"38;5;8",
         "Light-Red-fg":"38;5;9",
         "Light-Green-fg":"38;5;10",
@@ -25,7 +34,8 @@ window.onload = () => {
         "Light-Cyan-fg":"38;5;14",
         "White-fg":"38;5;15",
         "Default-fg":"39",
-        
+
+        /*
         "Black-bg":"40",
         "Dark-Red-bg":"41",
         "Dark-Green-bg":"42",
@@ -33,7 +43,15 @@ window.onload = () => {
         "Dark-Blue-bg":"44",
         "Dark-Magenta-bg":"45",
         "Dark-Cyan-bg":"46",
-        "Light-Gray-bg":"47",
+        "Light-Gray-bg":"47",*/
+        "Black-bg":"48;5;0",
+        "Dark-Red-bg":"48;5;1",
+        "Dark-Green-bg":"48;5;2",
+        "Dark-Yellow-bg":"48;5;3",
+        "Dark-Blue-bg":"48;5;4",
+        "Dark-Magenta-bg":"48;5;5",
+        "Dark-Cyan-bg":"48;5;6",
+        "Light-Gray-bg":"48;5;7",
         "Dark-Gray-bg":"48;5;8",
         "Light-Red-bg":"48;5;9",
         "Light-Green-bg":"48;5;10",
@@ -65,7 +83,7 @@ window.onload = () => {
     }
 
     let selFgcolor = (e) => {
-        if (settings.fgcolor === e.innerHTML){
+        if (settings.fgcolor === e.innerHTML.replace(/ /g,"-")){
             settings.fgcolor = ""
         }
         else{
@@ -76,7 +94,7 @@ window.onload = () => {
         updateOutput()
     }
     let selBgcolor = (e) => {
-        if (settings.bgcolor === e.innerHTML){
+        if (settings.bgcolor === e.innerHTML.replace(/ /g,"-")){
             settings.bgcolor = ""
         }
         else{
@@ -125,7 +143,7 @@ window.onload = () => {
         if (settings.fgcolor){
             output += codes[settings.fgcolor + "-fg"] + ";"
             fgcolor_btns.forEach(b => {
-                if (b.innerHTML === settings.fgcolor) {
+                if (b.innerHTML.replace(/ /g,"-") === settings.fgcolor) {
                     b.style.backgroundColor = "#507f9b"
                 }
             })
@@ -133,7 +151,7 @@ window.onload = () => {
         if (settings.bgcolor){
             output += codes[settings.bgcolor + "-bg"] + ";"
             bgcolor_btns.forEach(b => {
-                if (b.innerHTML === settings.bgcolor) {
+                if (b.innerHTML.replace(/ /g,"-") === settings.bgcolor) {
                     b.style.backgroundColor = "#507f9b"
                 }
             })

--- a/main.js
+++ b/main.js
@@ -42,6 +42,7 @@ window.onload = () => {
         "Light-Magenta-bg":"48;5;13",
         "Light-Cyan-bg":"48;5;14",
         "White-bg":"48;5;15",  
+        "Default-bg":"49",
 
         "Bold": "1",
         "Italic": "3",

--- a/main.js
+++ b/main.js
@@ -6,32 +6,47 @@ window.onload = () => {
     }
 
     const codes = {
-        "Reset": 0,
+        "Reset": "0",
 
-        "Black-fg":30,
-        "Red-fg":31,
-        "Green-fg":32,
-        "Yellow-fg":33,
-        "Blue-fg":34,
-        "Magenta-fg":35,
-        "Cyan-fg":36,
-        "White-fg":37,
-        "Default-fg":39,
+        "Black-fg":"30",
+        "Dark-Red-fg":"31",
+        "Dark-Green-fg":"32",
+        "Dark-Yellow-fg":"33",
+        "Dark-Blue-fg":"34",
+        "Dark-Magenta-fg":"35",
+        "Dark-Cyan-fg":"36",
+        "Light-Gray-fg":"37",
+        "Dark-Gray-fg":"38;5;8",
+        "Light-Red-fg":"38;5;9",
+        "Light-Green-fg":"38;5;10",
+        "Light-Yellow-fg":"38;5;11",
+        "Light-Blue-fg":"38;5;12",
+        "Light-Magenta-fg":"38;5;13",
+        "Light-Cyan-fg":"38;5;14",
+        "White-fg":"38;5;15",
+        "Default-fg":"39",
         
-        "Black-bg": 40,
-        "Red-bg": 41,
-        "Green-bg": 42,
-        "Yellow-bg": 43,
-        "Blue-bg": 44,
-        "Magenta-bg": 45,
-        "Cyan-bg": 46,
-        "White-bg": 47,
-        "Default-bg": 49,        
+        "Black-bg":"40",
+        "Dark-Red-bg":"41",
+        "Dark-Green-bg":"42",
+        "Dark-Yellow-bg":"43",
+        "Dark-Blue-bg":"44",
+        "Dark-Magenta-bg":"45",
+        "Dark-Cyan-bg":"46",
+        "Light-Gray-bg":"47",
+        "Dark-Gray-bg":"48;5;8",
+        "Light-Red-bg":"48;5;9",
+        "Light-Green-bg":"48;5;10",
+        "Light-Yellow-bg":"48;5;11",
+        "Light-Blue-bg":"48;5;12",
+        "Light-Magenta-bg":"48;5;13",
+        "Light-Cyan-bg":"48;5;14",
+        "White-bg":"48;5;15",  
 
-        "Bold": 1,
-        "Italic": 3,
-        "Underline": 4,
-        "Strikethrough": 9,
+        "Bold": "1",
+        "Italic": "3",
+        "Underline": "4",
+        "Strikethrough": "9",
     }
 
     const all_btns = document.querySelectorAll("button")
@@ -53,7 +68,7 @@ window.onload = () => {
             settings.fgcolor = ""
         }
         else{
-            settings.fgcolor = e.innerHTML
+            settings.fgcolor = e.innerHTML.replace(/ /g,"-")
         }
 
         settings.reset = false
@@ -64,7 +79,7 @@ window.onload = () => {
             settings.bgcolor = ""
         }
         else{
-            settings.bgcolor = e.innerHTML
+            settings.bgcolor = e.innerHTML.replace(/ /g,"-")
         }
 
         settings.reset = false


### PR DESCRIPTION
added light colors as not all terminal emulators will make bold colors light (such as kitty)

to use light colors without bold you'd need to use `38;5;N` instead of `1;3N`

i would've kept the dark colors as `3N` but if select bold, some terminal emulators will make it light, however `38;5;N` won't go light

i've also made the italic/bold/underline/strikethrough buttons have their style, and the colored buttons have their color as an outline

![image](https://user-images.githubusercontent.com/48314599/153180248-8565c57a-3441-4a63-9ec9-f9a9077c5719.png)
